### PR TITLE
Update ClaimService.java

### DIFF
--- a/app/src/main/java/org/parasol/ai/ClaimService.java
+++ b/app/src/main/java/org/parasol/ai/ClaimService.java
@@ -27,7 +27,7 @@ public interface ClaimService {
     @UserMessage("""
         Claim ID: {{query.claimId}}
 
-        Claim Inception Date: {{query.inceptionDate}}
+        Policy Inception Date: {{query.inceptionDate}}
 
         Claim Summary:
         {{query.claim}}


### PR DESCRIPTION
Declare inceptionDate as "Policy Inception Date" - the date on which the policy began, not the date of the claim. This helps LLMs calculate whether a claim falls within a policy term period.