### PR TITLE
Remove no longer necessary blocking annotation

### DIFF
--- a/app/src/main/java/org/parasol/resources/ClaimWebsocketChatBot.java
+++ b/app/src/main/java/org/parasol/resources/ClaimWebsocketChatBot.java
@@ -44,7 +44,6 @@ public class ClaimWebsocketChatBot {
 
     @OnTextMessage
     @WithSpan("ChatMessage")
-    @Blocking
     public Multi<ClaimBotQueryResponse> onMessage(ClaimBotQuery query) {
         Log.infof("Got chat query: %s", query);
 


### PR DESCRIPTION
Having bumped quarkus-langchain4j to 0.22.0 version makes that `@Blocking` annotation no longer necessary thanks to this fix https://github.com/quarkiverse/quarkus-langchain4j/commit/b1fe7df33bd54aa312bdb4b523d5063d7b08c393