### PR TITLE
Change stop to work for all chat model providers

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -2,12 +2,12 @@
 quarkus.langchain4j.parasol-chat.chat-model.provider=openai
 quarkus.langchain4j.log-requests=true
 quarkus.langchain4j.log-responses=true
+quarkus.langchain4j.parasol-chat.chat-model.stop=DONE,done,stop,STOP
 
 # OpenAI
 quarkus.langchain4j.openai.parasol-chat.chat-model.temperature=0.3
 quarkus.langchain4j.openai.parasol-chat.timeout=600s
 quarkus.langchain4j.openai.parasol-chat.chat-model.model-name=parasol-chat
-quarkus.langchain4j.openai.parasol-chat.chat-model.stop=DONE,done,stop,STOP
 quarkus.langchain4j.openai.parasol-chat.base-url=https://localhost:8000/v1
 quarkus.tls.trust-all=true
 


### PR DESCRIPTION
The "stop" or "done" keyword should work for all chat model providers. I was testing the jlama implementation and it was glitching a bit and writing endless responses, and the only way to stop it was to kill the app.  With the "stop" keywords I could've interrupted the AI response and continued with a next prompt.